### PR TITLE
removed the need for mahotas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "scipy >=1.5.4",
     "matplotlib >= 3.3.3",
     "scikit-learn >= 0.24.0",
-    "mahotas >= 1.4.11",
 ]
 
 [project.optional-dependencies]

--- a/src/songdkl/audio.py
+++ b/src/songdkl/audio.py
@@ -1,5 +1,4 @@
 import numpy as np
-from mahotas import otsu
 import scipy.signal as signal
 from scipy.io import wavfile
 from scipy import ndimage
@@ -60,10 +59,12 @@ def threshold(a, thresh=None):
     return out
 
 
+# TODO: add option to use scikit-image implementation of Otsu's method
+# https://github.com/NickleDave/songdkl/issues/37
 def findobject(file):
     """finds objects.  Expects a smoothed rectified amplitude envelope"""
-    value = (otsu(np.array(file, dtype=np.uint32))) / 2  # calculate a threshold
-    # value=(np.average(file))/2 #heuristically, this also usually works  for establishing threshold
+    # heuristic way of establishing threshold
+    value = (np.average(file)) / 2
     thresh = threshold(file, value)  # threshold the envelope data
     thresh = threshold(ndimage.convolve(thresh, np.ones(512)), 0.5)  # pad the threshold
     label = (ndimage.label(thresh)[0])  # label objects in the threshold


### PR DESCRIPTION
Removed the need for mahotas by eliminating the use of Otsu's method for calculating an amplitude threshold.  The threshold is now calculated using a heuristic based on amplitude.  This method worked well for my well curated bengalese finch song, but it may not work well for zebrafinch song.  In the future, we will try to switch this back to using Otsu's method buy taking advantage of the implementation in skimage.