### PR TITLE
ENH: Parallelize data prep with dask, fix #18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+    "dask >=2022.12.0",
     "numpy >=1.19.4",
     "scipy >=1.5.4",
     "matplotlib >= 3.3.3",

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -37,10 +37,9 @@ def test_SyllablesFromWav():
 
 @pytest.mark.smoke
 def test_get_all_syls(list_of_wav_paths):
-    wav_paths = list_of_wav_paths[:4]  # just need a short list for a smoke test
-    out = songdkl.syllables.get_all_syls(wav_paths)
+    out = songdkl.syllables.get_all_syls(list_of_wav_paths)
     assert isinstance(out, list)
-    assert len(out) == len(wav_paths)
+    assert len(out) == len(list_of_wav_paths)
     assert all(
         [isinstance(element, songdkl.syllables.SyllablesFromWav)
          for element in out]
@@ -49,8 +48,7 @@ def test_get_all_syls(list_of_wav_paths):
 
 @pytest.mark.smoke
 def test_convert_syl_to_psd(list_of_wav_paths):
-    wav_paths = list_of_wav_paths[:4]  # just need a short list for a smoke test
-    syls_from_wavs = songdkl.syllables.get_all_syls(wav_paths)
+    syls_from_wavs = songdkl.syllables.get_all_syls(list_of_wav_paths)
     psds = songdkl.syllables.convert_syl_to_psd(syls_from_wavs)
     assert isinstance(psds, list)
     assert all(


### PR DESCRIPTION
- DEV: Add dask as dependency in pyproject.toml
- Rewrite songdkl/syllables.py functions to use dask
- Modify unit tests in test_syllables.py
  + Running with only 4 files made it seem like `dask` actually slowed us down. But running with all 35 cuts time in half. More likely users will run with >>> 4 .wav files.