### PR TITLE
BUG: Fix how __main__ handles output_dir_path arg

### DIFF
--- a/src/songdkl/__main__.py
+++ b/src/songdkl/__main__.py
@@ -22,7 +22,17 @@ def main(argv=None):
     log_version(logger)
 
     if args.command == 'prep':
-        prep_and_save(dir_path=args.dir_path, output_dir_path=args.output_dir_path,
+        # handle edge case where user passes only one output dir,
+        # but argparse wraps in list because nargs='+'.
+        # We don't want `prep_and_save` responsible for catching it since this is a cli thing.
+        if args.output_dir_path is not None:
+            if len(args.output_dir_path) == 1:
+                output_dir_path = args.output_dir_path[0]
+            else:
+                output_dir_path = args.output_dir_path
+        else:
+            output_dir_path = None
+        prep_and_save(dir_path=args.dir_path, output_dir_path=output_dir_path,
                       max_wavs=args.max_wavs, max_num_psds=args.max_num_psds)
 
     elif args.command == 'calculate':


### PR DESCRIPTION
Because the --output_dir_path arg uses narg='+', it will always be a list, even if there's one output_dir. This circumvents logic in `prep_and_save` to catch the case where a user passes only one output_dir, that duplicates the string or pathlib.Path to be a list as long as the `dir_path` list.

We don't want `prep_and_save` to have to know about what the argparser does, so we catch this one-element list inside `main` and change it to just the single string, and then let `prep_and_save` duplicate it for every `dir_path`.