### PR TITLE
Save segmentation as annotation, fix #68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         run: |
           nox -s test-data-download-source
           nox -s test-data-download-generated
+      - name: install libsndfile1 on ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libsndfile1
       - name: run tests
         run: |
           pip install nox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+    "crowsetta >=4.0.0.post2",
     "dask >=2022.12.0",
     "numpy >=1.19.4",
     "scipy >=1.5.4",

--- a/src/songdkl/audio.py
+++ b/src/songdkl/audio.py
@@ -72,7 +72,7 @@ def apply_threshold(audio_arr: np.ndarray, thresh: int | float | None = None) ->
     return np.where(abs(audio_arr) > thresh, audio_arr, np.zeros(audio_arr.shape))
 
 
-def segment_audio(audio_arr: np.ndarray) -> list[tuple[slice]]:
+def segment_audio(audio_arr: np.ndarray) -> list[slice]:
     """Segment audio into clips containing syllables,
     using ``scipy.ndimage.find_objects``.
     Expects ``audio_arr`` to have zero elements, e.g.,
@@ -91,14 +91,17 @@ def segment_audio(audio_arr: np.ndarray) -> list[tuple[slice]]:
 
     Returns
     -------
-    objs : list
-        Of tuples of slices;
-        the segments identified by
+    slices : list
+        Of slices; the segments identified by
         ``scipy.ndimage.find_objects``.
     """
     label, _ = ndimage.label(audio_arr)  # label objects in the threshold
     objs = ndimage.find_objects(label)  # recover object positions
-    return objs
+    # find_objects returns a list of tuples with eacht uple containing N slices,
+    # N being the dimension of the input array.
+    # We assume audio is one dimensional so we just take the slices from the length-1 tuples
+    slices = [slice_tup[0] for slice_tup in objs]
+    return slices
 
 
 def get_syllable_clips_from_audio(audio_arr: np.ndarray,
@@ -138,7 +141,7 @@ def get_syllable_clips_from_audio(audio_arr: np.ndarray,
     syllable_clips : list
         Of ``numpy.ndarray``.
     slices : list
-        Of tuples of slices.
+        Of slices.
     threshold_val : float or int
         Threshold value obtained
         using the method specified by

--- a/src/songdkl/load.py
+++ b/src/songdkl/load.py
@@ -48,7 +48,8 @@ def load_or_prep(data_path: str | pathlib.Path,
             )
         segedpsds = load(zarr_path=data_path)
     elif data_path.is_dir():
-        segedpsds = prep(data_path, max_wavs, max_num_psds)
+        # we don't return syls_from_wavs
+        _, segedpsds = prep(data_path, max_wavs, max_num_psds)
     else:
         raise ValueError(
             f'Not recognized as a .zarr file or a directory: {data_path}'

--- a/src/songdkl/syllables.py
+++ b/src/songdkl/syllables.py
@@ -47,11 +47,23 @@ class SyllablesFromWav:
     syls : list
         Of ``numpy.ndarray``, syllables
         returned by ``songdkl.audio.getsyls``
+    slices: list
+        Of ``slice`` objects,
+        returned by ``audio.get_syllable_clips_from_audio``
+    threshold: float
+        Threshold value returned by
+        ``audio.get_syllable_clips_from_audio``.
+    wav_path : str, pathlib.Path
+        Path to .wav file that syllables were generated from.
     rate : int
         Sampling rate of .wav file.
     """
     syls: list[np.ndarray]
+    slices: list[slice]
+    threshold: float
+    wav_path: str | pathlib.Path
     rate: int
+
 
 
 def get_all_syls(wav_paths: list[str] | list[pathlib.Path]) -> list[SyllablesFromWav]:
@@ -76,11 +88,11 @@ def get_all_syls(wav_paths: list[str] | list[pathlib.Path]) -> list[SyllablesFro
     """
     bag = dask.bag.from_sequence(wav_paths)
 
-    # for wav_path in rich.progress.track(wav_paths, description='Getting syllables from .wav files'):
     def _syllabify(wav_path):
         rate, data = audio.load_wav(wav_path)
         syls_this_wav, slices_this_wav, threshold_value = audio.get_syllable_clips_from_audio(data, rate)
-        return SyllablesFromWav(syls=syls_this_wav, rate=rate)
+        return SyllablesFromWav(syls=syls_this_wav, slices=slices_this_wav, threshold=threshold_value,
+                                wav_path=wav_path, rate=rate)
 
     with dask.diagnostics.progress.ProgressBar():
         syls_from_wavs = bag.map(_syllabify).compute()

--- a/tests/fixtures/data.py
+++ b/tests/fixtures/data.py
@@ -65,10 +65,16 @@ def generated_song_data_root():
     return GENERATED_SONG_DATA_ROOT
 
 
-SONG_DATA_ZARR_PATHS = [
-    GENERATED_SONG_DATA_ROOT / dir_.name / f'{dir_.name}.songdkl.zarr'
-    for dir_ in SONG_DATA_SUBDIRS
+GENERATED_SONG_DATA_SUBDIRS = [
+    dir_ for dir_ in GENERATED_SONG_DATA_ROOT.iterdir()
+    if dir_.is_dir()
 ]
+
+
+SONG_DATA_ZARR_PATHS = []
+for generated_song_data_subdir in GENERATED_SONG_DATA_SUBDIRS:
+    zarr_path = sorted(generated_song_data_subdir.glob('*.songdkl.zarr'))
+    SONG_DATA_ZARR_PATHS.append(zarr_path[0])
 
 
 @pytest.fixture

--- a/tests/scripts/make_generated_test_data.py
+++ b/tests/scripts/make_generated_test_data.py
@@ -36,28 +36,32 @@ def prep_and_save():
                                    output_dir_path=output_dir_path)
 
 
-# --- main script ----
-print(
-    "Generating data for tests."
-)
+def main():
+    # --- main script ----
+    print(
+        "Generating data for tests."
+    )
 
-print(
-    "Preparing and saving arrays of PSDs from syllable segments."
-)
-prep_and_save()
+    print(
+        "Preparing and saving arrays of PSDs from syllable segments."
+    )
+    prep_and_save()
 
-print(
-    f'making archive from {GENERATED_SONG_DATA_ROOT}'
-)
-shutil.make_archive(
-    './tests/data-for-tests/generated/generated-test-data',
-    'gztar',
-    root_dir=GENERATED_DATA_ROOT,
-    # specify `base_dir` since we only want to archive song_data
-    base_dir="song_data",  # needs to be written relative to root
-)
+    print(
+        f'making archive from {GENERATED_SONG_DATA_ROOT}'
+    )
+    shutil.make_archive(
+        './tests/data-for-tests/generated/generated-test-data',
+        'gztar',
+        root_dir=GENERATED_DATA_ROOT,
+        # specify `base_dir` since we only want to archive song_data
+        base_dir="song_data",  # needs to be written relative to root
+    )
+
+    print(
+        "Done preparing generated data for tests."
+    )
 
 
-print(
-    "Done preparing generated data for tests."
-)
+if __name__ == '__main__':
+    main()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -43,16 +43,10 @@ WINDOW_FOR_FINDOBJ = 2
 def test_segment_audio(samp_freq_and_wav_data):
     samp_freq, data = samp_freq_and_wav_data
     smoothrect = songdkl.audio.smoothrect(data, WINDOW_FOR_FINDOBJ, samp_freq)
-    objs = songdkl.audio.segment_audio(smoothrect)
-    assert isinstance(objs, list)
+    slices = songdkl.audio.segment_audio(smoothrect)
+    assert isinstance(slices, list)
     assert all(
-        [isinstance(obj, tuple) for obj in objs]
-    )
-    assert all(
-        [len(obj) == 1 for obj in objs]
-    )
-    assert all(
-        [isinstance(obj[0], slice) for obj in objs]
+        [isinstance(slice_, slice) for slice_ in slices]
     )
 
 
@@ -69,13 +63,7 @@ def test_get_syllable_clips_from_audio(samp_freq_and_wav_data):
 
     assert isinstance(slices, list)
     assert all(
-        [isinstance(slice_, tuple) for slice_ in slices]
-    )
-    assert all(
-        [len(slice_) == 1 for slice_ in slices]
-    )
-    assert all(
-        [isinstance(slice_[0], slice) for slice_ in slices]
+        [isinstance(slice_, slice) for slice_ in slices]
     )
 
     assert isinstance(threshold_value, float)
@@ -108,9 +96,8 @@ def test_get_syllable_clips_from_audio_threshold_iou(threshold_method,
                                                                rate,
                                                                threshold=threshold_method)
     label_vec = np.zeros_like(audio_arr)
-    for slice_tup in slices:
-        slice = slice_tup[0]
-        label_vec[slice.start:slice.stop] = 1.0
+    for slice_ in slices:
+        label_vec[slice_.start:slice_.stop] = 1.0
     reference_df = bird_slice_df[bird_slice_df.filename == wav_path.name]
     reference_start, reference_stop = reference_df.start.values, reference_df.stop.values
     reference_label_vec = np.zeros_like(audio_arr)

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 
 import numpy as np
@@ -37,17 +38,17 @@ def test_prep(dir_path, max_wavs, max_num_psds, kwargify):
         # default max_wavs, max_num_psds
         (SONG_DATA_SUBDIRS_SMALL[0], None, None, None,),
         (SONG_DATA_SUBDIRS_SMALL, None, None, None),
-        (SONG_DATA_SUBDIRS_SMALL[0], str([0])+'out', None, None),
+        (SONG_DATA_SUBDIRS_SMALL[0], str(SONG_DATA_SUBDIRS_SMALL[0]) + '-out', None, None),
         (SONG_DATA_SUBDIRS_SMALL, [f'{subdir.name}-out' for subdir in SONG_DATA_SUBDIRS_SMALL], None, None),
         # default max_wavs, but specify max_num_psds
         (SONG_DATA_SUBDIRS_SMALL[0], None, None, 50),
         (SONG_DATA_SUBDIRS_SMALL, None, None, 50),
-        (SONG_DATA_SUBDIRS_SMALL[0], str([0])+'out', None, 50),
+        (SONG_DATA_SUBDIRS_SMALL[0], str(SONG_DATA_SUBDIRS_SMALL[0]) + '-out', None, 50),
         (SONG_DATA_SUBDIRS_SMALL, [f'{subdir.name}-out' for subdir in SONG_DATA_SUBDIRS_SMALL], None, 50),
         # specify max_wavs and max_num_psds
         (SONG_DATA_SUBDIRS_SMALL[0], None, 2, 50),
         (SONG_DATA_SUBDIRS_SMALL, None, 2, 50),
-        (SONG_DATA_SUBDIRS_SMALL[0], str([0]) + 'out', 2, 50),
+        (SONG_DATA_SUBDIRS_SMALL[0], str(SONG_DATA_SUBDIRS_SMALL[0]) + '-out', 2, 50),
         (SONG_DATA_SUBDIRS_SMALL, [f'{subdir.name}-out' for subdir in SONG_DATA_SUBDIRS_SMALL], 2, 50),
     ]
 )
@@ -61,6 +62,8 @@ def test_prep_and_save(dir_path, output_dir_path, max_wavs, max_num_psds, tmp_pa
     if output_dir_path:
         if isinstance(output_dir_path, (str, pathlib.Path)):
             output_dir_path = tmp_path / output_dir_path
+            if output_dir_path.exists():
+                shutil.rmtree(output_dir_path)
             output_dir_path.mkdir()
         elif isinstance(output_dir_path, list):
             output_dir_path = [
@@ -68,6 +71,8 @@ def test_prep_and_save(dir_path, output_dir_path, max_wavs, max_num_psds, tmp_pa
                 for output_dir_ in output_dir_path
             ]
             for p_ in output_dir_path:
+                if p_.exists():
+                    shutil.rmtree(p_)
                 p_.mkdir()
     kwargs = kwargify(dir_path=dir_path, output_dir_path=output_dir_path,
                       max_wavs=max_wavs, max_num_psds=max_num_psds)
@@ -76,21 +81,27 @@ def test_prep_and_save(dir_path, output_dir_path, max_wavs, max_num_psds, tmp_pa
 
     if isinstance(dir_path, pathlib.Path):
         dir_path = [dir_path]
-    if not output_dir_path:
-        for dir_path_ in dir_path:
-            expected = dir_path_ / f'{dir_path_.name}.songdkl.zarr'
-            assert expected.exists()
-            saved = zarr.load(expected)
-            assert isinstance(saved, np.ndarray)
-            if max_num_psds:
-                assert saved.shape[0] <= max_num_psds
-    else:
-        if isinstance(output_dir_path, pathlib.Path):
-            output_dir_path = [output_dir_path]
-        for dir_path_, output_dir_path_ in zip(dir_path, output_dir_path):
-            expected = output_dir_path_ / f'{dir_path_.name}.songdkl.zarr'
-            assert expected.exists()
-            saved = zarr.load(expected)
-            assert isinstance(saved, np.ndarray)
-            if max_num_psds:
-                assert saved.shape[0] <= max_num_psds
+    if output_dir_path is None:
+        # use `dir_path` as `output_dir_path`
+        output_dir_path = copy.deepcopy(dir_path)
+    elif isinstance(output_dir_path, pathlib.Path):
+        output_dir_path = [output_dir_path]
+    for a_dir_path, an_output_dir_path in zip(dir_path, output_dir_path):
+        wav_paths = sorted(a_dir_path.glob('*.wav'))
+        if max_wavs:
+            wav_paths = wav_paths[:max_wavs]
+        for wav_path in wav_paths:
+            simple_seq_path = sorted(an_output_dir_path.glob(f'{wav_path.name}-threshold-*'))
+            assert len(simple_seq_path) == 1
+            simple_seq_path = simple_seq_path[0]
+            assert simple_seq_path.exists()
+        generic_seq_path = an_output_dir_path / f'{a_dir_path.name}.annot.csv'
+        assert generic_seq_path.exists()
+
+        # NOTE an_output_dir_path can be == dir_path here
+        expected = an_output_dir_path / f'{a_dir_path.name}.songdkl.zarr'
+        assert expected.exists()
+        saved = zarr.load(expected)
+        assert isinstance(saved, np.ndarray)
+        if max_num_psds:
+            assert saved.shape[0] <= max_num_psds

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -25,10 +25,17 @@ SONG_DATA_SUBDIRS_SMALL = [
 @pytest.mark.parametrize('max_num_psds', [None, 10, 100])
 def test_prep(dir_path, max_wavs, max_num_psds, kwargify):
     kwargs = kwargify(dir_path=dir_path, max_wavs=max_wavs, max_num_psds=max_num_psds)
-    data = songdkl.prep.prep(**kwargs)
-    assert isinstance(data, np.ndarray)
+    out = songdkl.prep.prep(**kwargs)
+    assert len(out) == 2
+    syls_from_wavs, segedpsds = out
+    assert isinstance(syls_from_wavs, list)
+    assert all([isinstance(syls_from_wav, songdkl.syllables.SyllablesFromWav)
+                for syls_from_wav in syls_from_wavs])
+    if max_wavs:
+        assert len(syls_from_wavs) <= max_wavs
+    assert isinstance(segedpsds, np.ndarray)
     if max_num_psds:
-        assert data.shape[0] <= max_num_psds
+        assert segedpsds.shape[0] <= max_num_psds
 
 
 @pytest.mark.smoke

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -61,7 +61,7 @@ def test_prep(dir_path, max_wavs, max_num_psds, kwargify):
 )
 def test_prep_and_save(dir_path, output_dir_path, max_wavs, max_num_psds, tmp_path, kwargify):
     if isinstance(dir_path, pathlib.Path):
-        dir_path = shutil.copytree(dir_path, tmp_path, dirs_exist_ok=True)
+        dir_path = shutil.copytree(dir_path, tmp_path / dir_path.name, dirs_exist_ok=True)
     elif isinstance(dir_path, list):
         dir_path = [
             shutil.copytree(dir_path_, tmp_path / dir_path_.name, dirs_exist_ok=True) for dir_path_ in dir_path

--- a/tests/test_syllables.py
+++ b/tests/test_syllables.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy as np
 import pytest
 
@@ -21,18 +23,34 @@ def test_norm_wav_data(wav_data):
     np.testing.assert_almost_equal(out.std(), 1.0)
 
 
+def syls_from_wav_has_expected_attrs(syls_from_wav):
+    assert isinstance(syls_from_wav, songdkl.syllables.SyllablesFromWav)
+    assert hasattr(syls_from_wav, 'syls')
+    assert isinstance(syls_from_wav.syls, list)
+    assert hasattr(syls_from_wav, 'slices')
+    assert isinstance(syls_from_wav.syls, list)
+    assert hasattr(syls_from_wav, 'rate')
+    assert isinstance(syls_from_wav.rate, int)
+    assert hasattr(syls_from_wav, 'threshold')
+    assert isinstance(syls_from_wav.threshold, float)
+    assert hasattr(syls_from_wav, 'wav_path')
+    assert isinstance(syls_from_wav.wav_path, pathlib.Path)
+
+
 @pytest.mark.smoke
 def test_SyllablesFromWav():
     fake_syllables = [
         np.random.rand(3200, 1) for _ in range(10)
     ]
-    rate = 3200
-    syls_from_wav = songdkl.syllables.SyllablesFromWav(fake_syllables, rate)
-    assert isinstance(syls_from_wav, songdkl.syllables.SyllablesFromWav)
-    assert hasattr(syls_from_wav, 'syls')
-    assert isinstance(syls_from_wav.syls, list)
-    assert hasattr(syls_from_wav, 'rate')
-    assert isinstance(syls_from_wav.rate, int)
+    fake_slices = [
+        slice(0, fake_syl.shape[0]) for fake_syl in fake_syllables
+    ]
+    rate = 32000
+    threshold = 0.5
+    wav_path = pathlib.Path('dummy.wav')
+    syls_from_wav = songdkl.syllables.SyllablesFromWav(
+        syls=fake_syllables, slices=fake_slices, threshold=threshold, wav_path=wav_path, rate=rate)
+    syls_from_wav_has_expected_attrs(syls_from_wav)
 
 
 @pytest.mark.smoke
@@ -44,6 +62,8 @@ def test_get_all_syls(list_of_wav_paths):
         [isinstance(element, songdkl.syllables.SyllablesFromWav)
          for element in out]
     )
+    for element in out:
+        syls_from_wav_has_expected_attrs(element)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
Have `songdkl.prep.prep_and_save` also save the onsets and offsets of segments found by `songdkl.audio.get_syls_from_wav` to annotation files, so a user can inspect the segmentation. Fixes #68.

To do this, we
- [x] add attributes to the `SylsFromWav` dataclass that make it easier to track and save the output of `get_syls_from_wavs`: `slices`, a list of the slices used to get the "syls", i.e. the start and stop indices of the numpy arrays representing the syllables in the audio array), `threshold`, the threshold used to segment the audio array, and `wav_path`, the path to the .wav file that the segments are from.
- [x] return slices and threshold along with syllable clips from `audio.get_syllable_clips_from_audio(data, rate)` and use them all when making instances of the updated `SylsFromWav` 
- [x] add `crowsetta` as a dependency to work with annotations 
- [x] unpack all attributes from update `SylsFromWav` inside `prep_and_save` to make `crowsetta.Sequence` instances that we save as both the 'simple-seq' format (one per .wav file) and the 'generic-seq' format (one file for all .wav files in directory).