### PR TITLE
Fix cross validation in numsyls and add parameters/cli args for gaussian mixture

### DIFF
--- a/src/songdkl/argparser/argparser.py
+++ b/src/songdkl/argparser/argparser.py
@@ -93,4 +93,21 @@ def get():
                                          "a good rule of thumb is to use 3 splits.")
                                    )
 
+    for subparser in (calculate_subparser, numsyls_subparser):
+        # add args for GaussianMixture that both subparsers use
+        subparser.add_argument('--max-iter', type=int, default=100000,
+                               help=('The number of EM iterations to perform when fitting GaussianMixture. '
+                                     'Default is 100000.'))
+        subparser.add_argument('--n-init', type=int, default=5,
+                               help=("The number of initializations to perform when fitting GaussianMixture. "
+                                     "The best results are kept. Default is 5."))
+        subparser.add_argument('--covariance-type', type=str, default='full',
+                               choices={'full', 'tied', 'diag', 'spherical'},
+                               help=("String describing the type of covariance parameters to use"
+                                     "when fitting GaussianMixture. Default is 'full'."))
+        subparser.add_argument('--random-state', type=int, default=42,
+                               help="Int seed to random number generator. Default is 42.")
+        subparser.add_argument('--reg-covar', type=float, default=1e-6,
+                               help=("Non-negative regularization added to the diagonal of covariance "
+                                     "when fitting GaussianMixture. Default is 1e-6."))
     return parser

--- a/src/songdkl/constants.py
+++ b/src/songdkl/constants.py
@@ -1,2 +1,16 @@
+import dataclasses
+
+
 # format for timestamps
 STRFTIME_TIMESTAMP = "%y%m%d_%H%M%S"
+
+
+@dataclasses.dataclass
+class DefaultGaussianMixtureKwargs:
+    max_iter: int = 100000
+    n_init: int = 5
+    covariance_type: str = 'full'
+    random_state: int = 42
+
+
+DEFAULT_GMM_KWARGS = DefaultGaussianMixtureKwargs()

--- a/src/songdkl/numsyls.py
+++ b/src/songdkl/numsyls.py
@@ -98,10 +98,12 @@ def numsyls(psds_ref: np.ndarray,
         if n_splits > 1:
             split_bics = []
             splits = np.array_split(s, n_splits)
-            for split in splits:
+            for split_ind in range(len(splits)):
+                train_split = np.concatenate([split for ind, split in enumerate(splits) if ind != split_ind])
+                val_split = splits[split_ind]
                 gmm = GaussianMixture(n_components=n_components, max_iter=100000, n_init=5, covariance_type='full')
-                gmm.fit(split)
-                split_bics.append(gmm.bic(split))
+                gmm.fit(train_split)
+                split_bics.append(gmm.bic(val_split))
             bics.append(np.mean(split_bics))
         else:
             gmm = GaussianMixture(n_components=n_components, max_iter=100000, n_init=5, covariance_type='full')

--- a/src/songdkl/numsyls.py
+++ b/src/songdkl/numsyls.py
@@ -1,5 +1,6 @@
 """functions to estimate the number of syllables in a bird's song"""
 from __future__ import annotations
+import dataclasses
 import logging
 import pathlib
 
@@ -8,6 +9,7 @@ import rich.progress
 from sklearn.mixture import GaussianMixture
 import scipy.spatial
 
+from .constants import DefaultGaussianMixtureKwargs, DEFAULT_GMM_KWARGS
 from .load import load_or_prep
 
 
@@ -20,6 +22,7 @@ def numsyls(psds_ref: np.ndarray,
             min_components: int = 2,
             max_components: int = 22,
             n_splits: int = 1,
+            gmm_kwargs: DEFAULT_GMM_KWARGS | dict = DEFAULT_GMM_KWARGS,
             ) -> int:
     """Determine number of syllable classes in a bird's song.
 
@@ -53,6 +56,16 @@ def numsyls(psds_ref: np.ndarray,
         If sufficient data are available,
         a good rule of thumb is to use 3 splits.
         See Notes below for more detail.
+    gmm_kwargs : dict, DefaultGaussianMixtureKwargs
+        Optional dict with keyword argument to pass into
+        ``sklearn.GaussianMixtureModel`` when instantiating.
+        If not supplied, the defaults are used,
+        that are represented by a dataclass,
+        ``songdkl.constants.DefaultGaussianMixtureKwargs``.
+        Note that specifying ``n_components``
+        as one of the ``gmm_kwargs`` will raise an
+        error since this function searches for the best
+        value for ``n_components``.
 
     Returns
     -------
@@ -70,6 +83,21 @@ def numsyls(psds_ref: np.ndarray,
     human assessment or BIC values
     computed without splits.
     """
+    if isinstance(gmm_kwargs, DefaultGaussianMixtureKwargs):
+        gmm_kwargs = dataclasses.asdict(gmm_kwargs)
+    elif isinstance(gmm_kwargs, dict):
+        pass
+    else:
+        raise TypeError(
+            '`gmm_kwargs` must be a dict or DefaultGaussianMixtureKwargs,'
+            f'but was type: {type(gmm_kwargs)}'
+        )
+    if 'n_components' in gmm_kwargs:
+        raise ValueError(
+            "`gmm_kwargs` has key `n_components` but that argument to GaussianMixture "
+            "are the `k_ref` and `k_compare` arguments to this function."
+        )
+
     logger.log(
         msg=(f'Identifying best number of components to describe the data, psds_ref (shape: {psds_ref.shape}), '
              f'with parameters n_basis={n_basis}, basis={basis}, '
@@ -101,12 +129,12 @@ def numsyls(psds_ref: np.ndarray,
             for split_ind in range(len(splits)):
                 train_split = np.concatenate([split for ind, split in enumerate(splits) if ind != split_ind])
                 val_split = splits[split_ind]
-                gmm = GaussianMixture(n_components=n_components, max_iter=100000, n_init=5, covariance_type='full')
+                gmm = GaussianMixture(n_components=n_components, **gmm_kwargs)
                 gmm.fit(train_split)
                 split_bics.append(gmm.bic(val_split))
             bics.append(np.mean(split_bics))
         else:
-            gmm = GaussianMixture(n_components=n_components, max_iter=100000, n_init=5, covariance_type='full')
+            gmm = GaussianMixture(n_components=n_components, **gmm_kwargs)
             gmm.fit(np.array(s))
             bics.append(gmm.bic(np.array(s)))
     lowest_bic_ind = np.argmin(bics)
@@ -122,6 +150,7 @@ def numsyls_from_path(ref_path: str | pathlib.Path,
                       min_components: int = 2,
                       max_components: int = 22,
                       n_splits: int = 1,
+                      gmm_kwargs: DEFAULT_GMM_KWARGS | dict = DEFAULT_GMM_KWARGS,
                       ) -> int:
     """Determine number of syllable classes in a bird's song,
     by fitting Gaussian Mixture Models to PSDs of segmented
@@ -158,6 +187,16 @@ def numsyls_from_path(ref_path: str | pathlib.Path,
         If sufficient data are available,
         a good rule of thumb is to use 3 splits.
         See Notes below for more detail.
+    gmm_kwargs : dict, DefaultGaussianMixtureKwargs
+        Optional dict with keyword argument to pass into
+        ``sklearn.GaussianMixtureModel`` when instantiating.
+        If not supplied, the defaults are used,
+        that are represented by a dataclass,
+        ``songdkl.constants.DefaultGaussianMixtureKwargs``.
+        Note that specifying ``n_components``
+        as one of the ``gmm_kwargs`` will raise an
+        error since this function searches for the best
+        value for ``n_components``.
 
     Returns
     -------
@@ -173,5 +212,5 @@ def numsyls_from_path(ref_path: str | pathlib.Path,
     )
     psds_ref = load_or_prep(ref_path, max_wavs, max_num_psds)
 
-    sylno_bic = numsyls(psds_ref, n_basis, basis, min_components, max_components, n_splits)
+    sylno_bic = numsyls(psds_ref, n_basis, basis, min_components, max_components, n_splits, gmm_kwargs)
     return sylno_bic


### PR DESCRIPTION
This PR does two things:
- [x] fix cross-validation in the `numsyls` function, fixes #69 
- [x] adds the parameter `gmm_kwargs` to `numsyls` and `songdkl.calculate`, that allows a user to pass keyword arguments to `sklearn.mixture.GaussianMixture`, and also adds matching args to the cli so this can be done from the command line. Fixes #70    